### PR TITLE
feat(thegraph-proxy): add minimal thegraph proxy server for development

### DIFF
--- a/thegraph-proxy/.env.template
+++ b/thegraph-proxy/.env.template
@@ -1,0 +1,2 @@
+THEGRAPH_GATEWAY_DOMAIN="gateway.thegraph.com"
+THEGRAPH_API_KEY=

--- a/thegraph-proxy/README.md
+++ b/thegraph-proxy/README.md
@@ -1,0 +1,39 @@
+# TheGraph Proxy
+
+> ⚠️ Use this component for development purpose only
+
+Proxy server component relaying the calls to the decentralized thegraph network
+
+## Usage
+
+### prepare the `.env` file
+
+```sh
+cp .env.template .env
+```
+
+fill in `THEGRAPH_API_KEY` in the generated [.env](.env)
+
+### launch the **thegraph-proxy** service
+
+```sh
+docker compose up -d
+```
+
+The service is available at <http://localhost:8080>
+
+### use the service to query a subgraph
+
+example
+
+```js
+curl --request POST \
+  --url http://localhost:8080/subgraphs/id/2GCj8gzLCihsiEDq8cYvC5nUgK6VfwZ6hm3Wj8A3kcxz \
+  --data '{"query":"query {\n\t_meta {\n\t\tdeployment\n\t\thasIndexingErrors\n\t\tblock {\n\t\t\tnumber\n\t\t}\n\t}\n}\n"}'
+```
+
+### stop the service
+
+```sh
+docker compose down
+```

--- a/thegraph-proxy/docker-compose.yml
+++ b/thegraph-proxy/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  thegraph-proxy:
+    image: thegraph-proxy
+    build:
+      context: ./docker
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - '8080:80'
+    environment:
+      THEGRAPH_GATEWAY_DOMAIN: ${THEGRAPH_GATEWAY_DOMAIN}
+      THEGRAPH_API_KEY: ${THEGRAPH_API_KEY}

--- a/thegraph-proxy/docker/Dockerfile
+++ b/thegraph-proxy/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:alpine
+
+# Install envsubst (part of gettext)
+RUN apk add --no-cache gettext
+
+# Copy config template and entrypoint script
+COPY default.conf.template /etc/nginx/templates/default.conf.template
+COPY entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+
+# Make sure entrypoint is executable
+RUN chmod +x /docker-entrypoint.d/entrypoint.sh

--- a/thegraph-proxy/docker/default.conf.template
+++ b/thegraph-proxy/docker/default.conf.template
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+
+    location / {
+        proxy_pass https://${THEGRAPH_GATEWAY_DOMAIN}/api/${THEGRAPH_API_KEY}/;
+
+        proxy_ssl_server_name on;
+        
+        proxy_set_header Host ${THEGRAPH_GATEWAY_DOMAIN};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/thegraph-proxy/docker/entrypoint.sh
+++ b/thegraph-proxy/docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Replace env vars in template and save to nginx config dir
+envsubst '$THEGRAPH_GATEWAY_DOMAIN $THEGRAPH_API_KEY' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
+
+# Start nginx (inherited from base image entrypoint)
+exec "$@"


### PR DESCRIPTION
Add thegraph proxy for local development

The component proxies calls to the thegraph network while injecting API keys in the client requests

See [README.md](https://github.com/iExecBlockchainComputing/explorer-v2/blob/feat/development-thegraph-proxy/thegraph-proxy/README.md) for usage.