### PR TITLE
ci: lint PR title with conventional commit

### DIFF
--- a/.github/workflows/pr-conventional-commit.yml
+++ b/.github/workflows/pr-conventional-commit.yml
@@ -1,0 +1,14 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  lint-pr-title:
+    permissions:
+      pull-requests: read
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/conventional-commits.yml@conventional-commits-v1.0.1


### PR DESCRIPTION
Add lint on PR title to ensure the squash merge predefined commit message will respect the conventional commit