### PR TITLE
feat: update Arbitrum Sepolia urls

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,12 +24,12 @@ export const SUPPORTED_CHAINS = [
   {
     id: 421614,
     name: 'Arbitrum Sepolia',
-    slug: 'arbitrum-sepolia',
+    slug: 'arbitrum-sepolia-testnet',
     color: '#28A0F080',
     icon: arbitrumSepoliaIcon,
     blockExplorerUrl: 'https://sepolia.arbiscan.io/',
     subgraphUrl:
-      'https://thegraph.arbitrum-testnet.iex.ec/api/subgraphs/id/2GCj8gzLCihsiEDq8cYvC5nUgK6VfwZ6hm3Wj8A3kcxz',
+      'https://thegraph.arbitrum-sepolia-testnet.iex.ec/api/subgraphs/id/2GCj8gzLCihsiEDq8cYvC5nUgK6VfwZ6hm3Wj8A3kcxz',
     wagmiNetwork: arbitrumSepolia,
   },
 ];


### PR DESCRIPTION
Networks naming convention in URLs was discussed [here](https://iexec-team-private.slack.com/archives/C080UEZB0FL/p1750089864491829)
This changes how Arbitrum Sepolia must be exposed in URLs