### PR TITLE
style: fix arbitrum color

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export const SUPPORTED_CHAINS = [
     id: 42161,
     name: 'Arbitrum',
     slug: 'arbitrum-mainnet',
-    color: '#F4942566',
+    color: '#28A0F080',
     icon: arbitrumSepoliaIcon,
     blockExplorerUrl: 'https://arbiscan.io/',
     subgraphUrl:


### PR DESCRIPTION
## issue

Bellecour's color is assigned to Arbitrum

## change

| before | after |
| --- | --- |
| <img width="1677" height="390" alt="image" src="https://github.com/user-attachments/assets/90d40a20-f6bc-4e39-aa59-9893c0820fbc" /> |  <img width="1677" height="390" alt="image" src="https://github.com/user-attachments/assets/1f64b762-18b1-4919-8c91-076018fa7cdb" /> |