### PR TITLE
fix: don't display "Datasets bulk" on deals without dataset bulk

### DIFF
--- a/src/modules/deals/deal/buildDealDetails.tsx
+++ b/src/modules/deals/deal/buildDealDetails.tsx
@@ -106,21 +106,22 @@ export function buildDealDetails({
       ),
       'Dataset price': <p>{deal.datasetPrice}</p>,
     }),
-    ...(deal.dataset === null && {
-      Dataset: (
-        <p>
-          Datasets bulk{' '}
-          <Button
-            variant="link"
-            size="none"
-            className="ml-1"
-            onClick={onSeeTasks}
-          >
-            (see tasks for details)
-          </Button>
-        </p>
-      ),
-    }),
+    ...(deal.dataset === null &&
+      deal.bulk && {
+        Dataset: (
+          <p>
+            Datasets bulk{' '}
+            <Button
+              variant="link"
+              size="none"
+              className="ml-1"
+              onClick={onSeeTasks}
+            >
+              (see tasks for details)
+            </Button>
+          </p>
+        ),
+      }),
     ...(deal.workerpool && {
       Workerpool: (
         <div className="flex flex-wrap items-center gap-1">


### PR DESCRIPTION
The "Dataset" row was incorrectly displayed as "Datasets bulk" when a deal has no dataset or dataset bulk

Example with deal https://explorer.iex.ec/arbitrum-sepolia-testnet/deal/0xeb489bebd59399b245d1a15fe8710129f470177b71f2b1160d4ea704e6d744d6?dealTab=DETAILS (not bulk)

| before | after |
| --- | --- |
| <img width="1029" height="666" alt="image" src="https://github.com/user-attachments/assets/3bf45e0a-6d3f-4ad7-bd59-54ad108505b5" /> | <img width="1029" height="666" alt="image" src="https://github.com/user-attachments/assets/10a36c71-12a5-47ac-b722-588972d2f155" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-conditional change limited to deal details rendering; no security or data-handling logic is affected.
> 
> **Overview**
> Fixes deal details rendering so the **"Datasets bulk"** placeholder is only shown when `deal.dataset` is `null` *and* the deal is marked as `bulk`, preventing incorrect UI on non-bulk deals without a dataset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 768e89ccc4c95813f611a56d2f14fd33df908eca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->